### PR TITLE
feat: replace .opencode/ folder with git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".opencode"]
+	path = .opencode
+	url = git@github.com:michael-conrad/opencode-config.git


### PR DESCRIPTION
## Summary

Replace the local `.opencode/` folder with a git submodule pointing to the centralized configuration repository. This establishes a single source of truth for agent configuration and simplifies future updates.

## Changes

- Added `.opencode` as a git submodule (`git@github.com:michael-conrad/opencode-config.git`)
- Created `.gitmodules` with the submodule entry
- Submodule initialized at commit `0757e53c`

## Outcome

`.opencode/` is now a git submodule rather than a local folder. All agent configurations (skills, guidelines, tools) are sourced from the external repository and can be updated independently.

**Compare URL:** https://github.com/michael-conrad/gitbucket/compare/dev...feature/10-opencode-submodule

Implements #10