### PR TITLE
[SPEC #1, Task #5] Swagger Infrastructure and Core Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ project/plugins/project/
 # Visual Studio Code specific
 .vscode
 
+.worktrees/

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ libraryDependencies ++= Seq(
   "org.scalatra"             %% "scalatra-javax"               % ScalatraVersion,
   "org.scalatra"             %% "scalatra-json-javax"          % ScalatraVersion,
   "org.scalatra"             %% "scalatra-forms-javax"         % ScalatraVersion,
+  "org.scalatra"             %% "scalatra-swagger-javax"       % ScalatraVersion,
   "io.github.json4s"         %% "json4s-jackson"               % "4.1.0",
   "commons-io"                % "commons-io"                   % "2.22.0",
   "io.github.gitbucket"       % "solidbase"                    % "1.1.0",

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -2,6 +2,7 @@ import java.util.EnumSet
 import javax.servlet._
 
 import gitbucket.core.controller.{ReleaseController, _}
+import gitbucket.core.controller.api.SwaggerResourcesApp
 import gitbucket.core.service.SystemSettingsService
 import gitbucket.core.servlet._
 import gitbucket.core.util.Directory
@@ -38,6 +39,8 @@ class ScalatraBootstrap extends LifeCycle with SystemSettingsService {
       .addMappingForUrlPatterns(EnumSet.allOf(classOf[DispatcherType]), true, "/*")
 
     context.mount(new FileUploadController, "/upload")
+
+    context.mount(new SwaggerResourcesApp, "/api-docs")
 
     val filter = new CompositeScalatraFilter()
     filter.mount(new IndexController, "/")

--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -6,6 +6,7 @@ import gitbucket.core.service.*
 import gitbucket.core.util.Implicits.*
 import gitbucket.core.util.*
 import gitbucket.core.plugin.PluginRegistry
+import org.scalatra.swagger.{Swagger, SwaggerSupport}
 
 class ApiController
     extends ApiControllerBase
@@ -54,9 +55,15 @@ class ApiController
     with ReferrerAuthenticator
     with ReadableUsersAuthenticator
     with WritableUsersAuthenticator
-    with RequestCache
+    with RequestCache {
 
-trait ApiControllerBase extends ControllerBase {
+  override implicit lazy val swagger: Swagger = GitBucketSwagger
+}
+
+trait ApiControllerBase extends ControllerBase with SwaggerSupport {
+
+  override implicit lazy val swagger: Swagger = GitBucketSwagger
+  override protected def applicationDescription: String = "GitBucket API"
 
   /**
    * 404 for non-implemented api
@@ -81,6 +88,7 @@ trait ApiControllerBase extends ControllerBase {
    * https://developer.github.com/v3/#root-endpoint
    */
   get("/api/v3") {
+    apiOperation[ApiEndPoint]("getApiRoot").summary("Root endpoint")
     JsonFormat(ApiEndPoint())
   }
 

--- a/src/main/scala/gitbucket/core/controller/api/GitBucketSwagger.scala
+++ b/src/main/scala/gitbucket/core/controller/api/GitBucketSwagger.scala
@@ -1,0 +1,15 @@
+package gitbucket.core.controller.api
+
+import org.scalatra.swagger.{ApiInfo, ContactInfo, LicenseInfo, Swagger}
+
+object GitBucketSwagger extends Swagger(
+  swaggerVersion = "2.0",
+  apiVersion = "1.0",
+  apiInfo = ApiInfo(
+    title = "GitBucket API",
+    description = "GitBucket REST API documentation",
+    termsOfServiceUrl = "",
+    contact = ContactInfo("", "", ""),
+    license = LicenseInfo("", "")
+  )
+)

--- a/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
+++ b/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
@@ -1,0 +1,13 @@
+package gitbucket.core.controller.api
+
+import org.json4s.Formats
+import org.scalatra.ScalatraServlet
+import org.scalatra.swagger.{JacksonSwaggerBase, Swagger}
+
+class SwaggerResourcesApp(implicit override val swagger: Swagger = GitBucketSwagger)
+    extends ScalatraServlet
+    with JacksonSwaggerBase {
+
+  override implicit protected def jsonFormats: Formats =
+    gitbucket.core.api.JsonFormat.jsonFormats
+}

--- a/src/main/scala/gitbucket/core/servlet/CompositeScalatraFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/CompositeScalatraFilter.scala
@@ -22,7 +22,8 @@ abstract class ControllerFilter extends Filter {
 
     if (
       !checkPath.startsWith("/upload/") && !checkPath.startsWith("/git/") && !checkPath.startsWith("/git-lfs/") &&
-      !checkPath.startsWith("/assets/") && !checkPath.startsWith("/plugin-assets/")
+      !checkPath.startsWith("/assets/") && !checkPath.startsWith("/plugin-assets/") &&
+      !checkPath.startsWith("/api-docs/")
     ) {
       val continue = process(request, response, checkPath)
       if (!continue) {


### PR DESCRIPTION
## Summary

Wire in Scalatra SwaggerSupport to expose a live OpenAPI/Swagger 2.0 spec endpoint for GitBucket's REST API.

## Outcome

- `GET /api-docs/swagger.json` returns valid Swagger 2.0 JSON (SC-1 ✅)
- Zero regressions — all existing `/api/v3/*` endpoints unchanged (SC-3 ✅)
- Public access — no auth required for spec endpoint (SC-8 ✅)
- `scalatra-swagger-javax` 3.1.2 matches existing Scalatra version (SC-6 ✅)

Fixes #5

🤖 Co-authored with AI: OpenCode (glm-5.1)