### PR TITLE
feat(#24): add Swagger annotations to ApiIssueControllerBase

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Michael Conrad
+// SPDX-License-Identifier: Apache-2.0
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
 package gitbucket.core.controller.api
 import gitbucket.core.api._
 import gitbucket.core.controller.ControllerBase
@@ -7,10 +11,13 @@ import gitbucket.core.service.IssuesService.IssueSearchCondition
 import gitbucket.core.service.PullRequestService.PullRequestLimit
 import gitbucket.core.util.{ReadableUsersAuthenticator, ReferrerAuthenticator, RepositoryName}
 import gitbucket.core.util.Implicits._
+import org.scalatra.swagger.{ResponseMessage, Swagger, SwaggerSupport}
+import org.scalatra.swagger.SwaggerSupportSyntax._
 
 trait ApiIssueControllerBase extends ControllerBase {
   self: AccountService & IssuesService & IssueCreationService & MilestonesService & ReadableUsersAuthenticator &
-    ReferrerAuthenticator =>
+    ReferrerAuthenticator & SwaggerSupport =>
+
   /*
    * i. List issues
    * https://developer.github.com/v3/issues/#list-issues
@@ -21,7 +28,32 @@ trait ApiIssueControllerBase extends ControllerBase {
    * ii. List issues for a repository
    * https://developer.github.com/v3/issues/#list-issues-for-a-repository
    */
-  get("/api/v3/repos/:owner/:repository/issues")(referrersOnly { repository =>
+  val listIssuesOp =
+    apiOperation[List[ApiIssue]]("listIssues")
+      .summary("List issues for a repository")
+      .description("Returns a list of issues for the specified repository")
+      .parameters(
+        pathParam[String]("owner").description("Repository owner"),
+        pathParam[String]("repository").description("Repository name"),
+        queryParam[String]("state")
+          .description("Filter by state")
+          .allowableValues("open", "closed", "all")
+          .optional,
+        queryParam[String]("milestone").description("Milestone number or *").optional,
+        queryParam[String]("labels").description("Comma-separated label names").optional,
+        queryParam[String]("sort")
+          .description("Sort field")
+          .allowableValues("created", "updated", "comments")
+          .optional,
+        queryParam[String]("direction")
+          .description("Sort direction")
+          .allowableValues("asc", "desc")
+          .optional,
+        queryParam[String]("since").description("ISO 8601 timestamp").optional
+      )
+      .responseMessages(ResponseMessage(404, "Repository not found"))
+
+  get("/repos/:owner/:repository/issues", operation(listIssuesOp))(referrersOnly { repository =>
     val page = IssueSearchCondition.page(request)
     // TODO: more api spec condition
     val condition = IssueSearchCondition(request)
@@ -52,7 +84,18 @@ trait ApiIssueControllerBase extends ControllerBase {
    * iii. Get a single issue
    * https://developer.github.com/v3/issues/#get-a-single-issue
    */
-  get("/api/v3/repos/:owner/:repository/issues/:id")(referrersOnly { repository =>
+  val getIssueOp =
+    apiOperation[ApiIssue]("getIssue")
+      .summary("Get a single issue")
+      .description("Returns a single issue by its ID for the specified repository")
+      .parameters(
+        pathParam[String]("owner").description("Repository owner"),
+        pathParam[String]("repository").description("Repository name"),
+        pathParam[Int]("id").description("Issue number")
+      )
+      .responseMessages(ResponseMessage(404, "Issue not found"))
+
+  get("/repos/:owner/:repository/issues/:id", operation(getIssueOp))(referrersOnly { repository =>
     (for {
       issueId <- params("id").toIntOpt
       issue <- getIssue(repository.owner, repository.name, issueId.toString)
@@ -77,7 +120,21 @@ trait ApiIssueControllerBase extends ControllerBase {
    * iv. Create an issue
    * https://developer.github.com/v3/issues/#create-an-issue
    */
-  post("/api/v3/repos/:owner/:repository/issues")(readableUsersOnly { repository =>
+  val createIssueOp =
+    apiOperation[ApiIssue]("createIssue")
+      .summary("Create an issue")
+      .description("Create a new issue in the specified repository")
+      .parameters(
+        pathParam[String]("owner").description("Repository owner"),
+        pathParam[String]("repository").description("Repository name"),
+        bodyParam[CreateAnIssue]("body").description("Issue data")
+      )
+      .responseMessages(
+        ResponseMessage(401, "Unauthorized"),
+        ResponseMessage(404, "Repository not found")
+      )
+
+  post("/repos/:owner/:repository/issues", operation(createIssueOp))(readableUsersOnly { repository =>
     if (isIssueEditable(repository)) { // TODO Should this check is provided by authenticator?
       (for {
         data <- extractFromJsonBody[CreateAnIssue]

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2026 Michael Conrad
-// SPDX-License-Identifier: Apache-2.0
-// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
-
 package gitbucket.core.controller.api
 import gitbucket.core.api._
 import gitbucket.core.controller.ControllerBase

--- a/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/api/ApiIssueControllerBase.scala
@@ -1,3 +1,5 @@
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
 package gitbucket.core.controller.api
 import gitbucket.core.api._
 import gitbucket.core.controller.ControllerBase

--- a/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
+++ b/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Michael Conrad
 // SPDX-License-Identifier: Apache-2.0
-// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+// Co-authored with AI: OpenCode (ollama-cloud/kimi-k2.6:cloud), OpenCode (ollama-cloud/glm-5.1)
 
 package gitbucket.core.controller.api
 

--- a/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
+++ b/src/main/scala/gitbucket/core/controller/api/SwaggerResourcesApp.scala
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Michael Conrad
 // SPDX-License-Identifier: Apache-2.0
-// Co-authored with AI: OpenCode (ollama-cloud/kimi-k2.6:cloud)
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
 
 package gitbucket.core.controller.api
 
@@ -14,4 +14,18 @@ class SwaggerResourcesApp(implicit override val swagger: Swagger = GitBucketSwag
 
   override implicit protected def jsonFormats: Formats =
     gitbucket.core.api.JsonFormat.jsonFormats
+
+  // Strip any path parameters (e.g. ;jsessionid=...) from the
+  // computed basePath so swagger.json does not leak session ids
+  // when the docs endpoint is hit without a cookie. Scoped to
+  // this servlet only — does not affect session tracking
+  // anywhere else in the application.
+  override protected def bathPath: Option[String] = {
+    super.bathPath.map(stripPathParameters).filter(_.nonEmpty)
+  }
+
+  private def stripPathParameters(path: String): String = {
+    val semi = path.indexOf(';')
+    if (semi >= 0) path.substring(0, semi) else path
+  }
 }

--- a/src/test/scala/gitbucket/core/controller/api/ApiIssueControllerBaseSwaggerSpec.scala
+++ b/src/test/scala/gitbucket/core/controller/api/ApiIssueControllerBaseSwaggerSpec.scala
@@ -1,0 +1,120 @@
+package gitbucket.core.controller.api
+
+import org.json4s.jackson.JsonMethods
+import org.json4s._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
+import java.net.HttpURLConnection
+import java.net.URI
+
+class ApiIssueControllerBaseSwaggerSpec extends AnyFunSuite with BeforeAndAfterAll {
+
+  private var swaggerJson: JValue = _
+
+  private def fetchSwaggerJson(): JValue = {
+    var retries = 0
+    var lastException: Option[Exception] = None
+    while (retries < 30) {
+      try {
+        val url = URI.create("http://localhost:8080/api-docs/swagger.json").toURL
+        val conn = url.openConnection().asInstanceOf[HttpURLConnection]
+        conn.setRequestMethod("GET")
+        conn.setConnectTimeout(3000)
+        conn.setReadTimeout(3000)
+        if (conn.getResponseCode == 200) {
+          val source = scala.io.Source.fromInputStream(conn.getInputStream)
+          try {
+            return JsonMethods.parse(source.mkString)
+          } finally {
+            source.close()
+          }
+        }
+      } catch {
+        case e: Exception => lastException = Some(e)
+      }
+      Thread.sleep(1000)
+      retries += 1
+    }
+    throw lastException.getOrElse(new RuntimeException("Failed to fetch swagger.json after 30 retries"))
+  }
+
+  override def beforeAll(): Unit = {
+    swaggerJson = fetchSwaggerJson()
+  }
+
+  implicit val formats: Formats = DefaultFormats
+
+  private def getOperation(pathPattern: String, method: String): JValue = {
+    val allPaths = (swaggerJson \ "paths").extract[Map[String, JValue]]
+    val pathKey = allPaths.keys.find(_.contains(pathPattern)).get
+    allPaths(pathKey) \ method
+  }
+
+  test("swagger.json should contain listIssues GET endpoint") {
+    val op = getOperation("/repos/{owner}/{repository}/issues", "get")
+    val operationId = (op \ "operationId").extract[String]
+    assert(operationId == "listIssues", s"Expected operationId 'listIssues', got '$operationId'")
+    val summary = (op \ "summary").extract[String]
+    assert(summary.nonEmpty, "listIssues should have a summary")
+  }
+
+  test("swagger.json should contain getIssue GET endpoint") {
+    val op = getOperation("/repos/{owner}/{repository}/issues/{id}", "get")
+    val operationId = (op \ "operationId").extract[String]
+    assert(operationId == "getIssue", s"Expected operationId 'getIssue', got '$operationId'")
+    val params = (op \ "parameters").extract[List[JValue]]
+    val hasId = params.exists(p => (p \ "name").extract[String] == "id")
+    assert(hasId, "getIssue should have 'id' param")
+  }
+
+  test("swagger.json should contain createIssue POST endpoint") {
+    val op = getOperation("/repos/{owner}/{repository}/issues", "post")
+    val operationId = (op \ "operationId").extract[String]
+    assert(operationId == "createIssue", s"Expected operationId 'createIssue', got '$operationId'")
+    val params = (op \ "parameters").extract[List[JValue]]
+    val hasBody = params.exists(p => (p \ "name").extract[String] == "body")
+    assert(hasBody, "createIssue should have a 'body' parameter")
+  }
+
+  test("swagger.json should contain owner and repository path parameters for listIssues") {
+    val op = getOperation("/repos/{owner}/{repository}/issues", "get")
+    val params = (op \ "parameters").extract[List[JValue]]
+    val paramNames = params.map(p => (p \ "name").extract[String]).toSet
+    assert(paramNames.contains("owner"), s"listIssues should have 'owner' param, found: $paramNames")
+    assert(paramNames.contains("repository"), s"listIssues should have 'repository' param, found: $paramNames")
+  }
+
+  test("swagger.json listIssues should have enum constraints") {
+    val op = getOperation("/repos/{owner}/{repository}/issues", "get")
+    val params = (op \ "parameters").extract[List[JValue]]
+    val stateParam = params.find(p => (p \ "name").extract[String] == "state").get
+    val enumVals = (stateParam \ "enum").extract[List[String]]
+    assert(enumVals.contains("open"), s"state enum should contain 'open', got: $enumVals")
+    assert(enumVals.contains("closed"), s"state enum should contain 'closed', got: $enumVals")
+    assert(enumVals.contains("all"), s"state enum should contain 'all', got: $enumVals")
+  }
+
+  test("swagger.json paths should not have doubled /api/v3 prefix") {
+    val allPaths = (swaggerJson \ "paths").extract[Map[String, JValue]]
+    val doubled = allPaths.keys.filter(p => p.contains("/api/v3/api/v3/"))
+    assert(doubled.isEmpty, s"Paths must not contain doubled /api/v3 prefix, found: $doubled")
+  }
+
+  test("swagger.json basePath should not contain jsessionid") {
+    val basePath = swaggerJson \ "basePath"
+    if (basePath != JNothing) {
+      val bp = basePath.extract[String]
+      assert(!bp.contains("jsessionid"), s"basePath must not contain jsessionid, got: $bp")
+    }
+  }
+
+  test("swagger.json should contain ApiIssue model definition") {
+    val defs = (swaggerJson \ "definitions").extract[Map[String, JValue]]
+    assert(defs.contains("ApiIssue"), s"ApiIssue model should be registered, found: ${defs.keySet}")
+  }
+
+  test("swagger.json should contain CreateAnIssue model definition") {
+    val defs = (swaggerJson \ "definitions").extract[Map[String, JValue]]
+    assert(defs.contains("CreateAnIssue"), s"CreateAnIssue model should be registered, found: ${defs.keySet}")
+  }
+}

--- a/src/test/scala/gitbucket/core/controller/api/ApiIssueControllerBaseSwaggerSpec.scala
+++ b/src/test/scala/gitbucket/core/controller/api/ApiIssueControllerBaseSwaggerSpec.scala
@@ -1,3 +1,5 @@
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
 package gitbucket.core.controller.api
 
 import org.json4s.jackson.JsonMethods


### PR DESCRIPTION
## Summary

Adds Swagger annotations to ApiIssueControllerBase — val-bound operation pattern, stripped `/api/v3` route prefix, and jsessionid basePath fix.

## Outcome

`swagger.json` now documents the three issue endpoints (`listIssues`, `getIssue`, `createIssue`) with proper operationIds, enum constraints, and no doubled path prefix.

Fixes #24

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)