### PR TITLE
feat(#42): Populate swagger.json info block with license, contact, and termsOfService

### DIFF
--- a/src/main/scala/gitbucket/core/controller/api/GitBucketSwagger.scala
+++ b/src/main/scala/gitbucket/core/controller/api/GitBucketSwagger.scala
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Michael Conrad
 // SPDX-License-Identifier: Apache-2.0
-// Co-authored with AI: OpenCode (ollama-cloud/kimi-k2.6:cloud)
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
 
 package gitbucket.core.controller.api
 
@@ -9,13 +9,20 @@ import org.slf4j.LoggerFactory
 
 object GitBucketSwagger extends Swagger(
   swaggerVersion = "2.0",
-  apiVersion = "1.0",
+  apiVersion = GitBucketSwaggerVersion.current,
   apiInfo = ApiInfo(
     title = "GitBucket API",
     description = "GitBucket REST API documentation",
-    termsOfServiceUrl = "",
-    contact = ContactInfo("", "", ""),
-    license = LicenseInfo("", "")
+    termsOfServiceUrl = "Provided AS IS without warranty. See https://www.apache.org/licenses/LICENSE-2.0 for details.",
+    contact = ContactInfo(
+      name = "takezoe",
+      url = "https://gitbucket.github.io/",
+      email = "https://github.com/takezoe"
+    ),
+    license = LicenseInfo(
+      name = "Apache 2.0",
+      url = "https://www.apache.org/licenses/LICENSE-2.0"
+    )
   )
 ) {
   private val logger = LoggerFactory.getLogger(getClass)
@@ -28,4 +35,10 @@ object GitBucketSwagger extends Swagger(
       logger.info(s"Swagger resource pending registration: $listingPath -> $resourcePath (will register on controller initialization)")
     }
   }
+}
+
+object GitBucketSwaggerVersion {
+  lazy val current: String = Option(
+    classOf[GitBucketSwagger.type].getPackage.getImplementationVersion
+  ).getOrElse("0.0.0")
 }

--- a/src/test/scala/gitbucket/core/controller/api/GitBucketSwaggerSpec.scala
+++ b/src/test/scala/gitbucket/core/controller/api/GitBucketSwaggerSpec.scala
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 Michael Conrad
+// SPDX-License-Identifier: Apache-2.0
+// Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)
+
+package gitbucket.core.controller.api
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class GitBucketSwaggerSpec extends AnyFunSuite {
+
+  test("swagger apiVersion should not be hardcoded 1.0") {
+    assert(GitBucketSwagger.apiVersion != "1.0",
+      s"apiVersion should be dynamically resolved, got hardcoded '${GitBucketSwagger.apiVersion}'")
+  }
+
+  test("swagger info.termsOfService should be non-empty") {
+    assert(GitBucketSwagger.apiInfo.termsOfServiceUrl.nonEmpty,
+      "termsOfServiceUrl should contain a non-empty disclaimer string")
+  }
+
+  test("swagger info.license.name should be Apache 2.0") {
+    assert(GitBucketSwagger.apiInfo.license.name == "Apache 2.0",
+      s"Expected license.name 'Apache 2.0', got '${GitBucketSwagger.apiInfo.license.name}'")
+  }
+
+  test("swagger info.license.url should be Apache 2.0 URL") {
+    assert(GitBucketSwagger.apiInfo.license.url == "https://www.apache.org/licenses/LICENSE-2.0",
+      s"Expected license.url 'https://www.apache.org/licenses/LICENSE-2.0', got '${GitBucketSwagger.apiInfo.license.url}'")
+  }
+
+  test("swagger info.contact.name should be takezoe") {
+    assert(GitBucketSwagger.apiInfo.contact.name == "takezoe",
+      s"Expected contact.name 'takezoe', got '${GitBucketSwagger.apiInfo.contact.name}'")
+  }
+
+  test("swagger info.contact.url should be gitbucket.github.io") {
+    assert(GitBucketSwagger.apiInfo.contact.url == "https://gitbucket.github.io/",
+      s"Expected contact.url 'https://gitbucket.github.io/', got '${GitBucketSwagger.apiInfo.contact.url}'")
+  }
+
+  test("swagger info.contact.email should be takezoe GitHub URL") {
+    assert(GitBucketSwagger.apiInfo.contact.email == "https://github.com/takezoe",
+      s"Expected contact.email 'https://github.com/takezoe', got '${GitBucketSwagger.apiInfo.contact.email}'")
+  }
+}


### PR DESCRIPTION
## Summary

Populate the `info` object in `/api-docs/swagger.json` with meaningful values for `version`, `termsOfService`, `contact`, and `license` fields, replacing the empty/hardcoded placeholder values.

## Outcome

- Dynamic `apiVersion` via `GitBucketSwaggerVersion.current` (reads from JAR manifest `Implementation-Version`, falls back to `0.0.0`)
- `termsOfService` populated with AS-IS disclaimer referencing Apache 2.0
- `contact` populated with takezoe maintainer info
- `license` populated with Apache 2.0 license info
- 7 unit tests covering all acceptance criteria (all passing)
- No regressions in existing test suite (2 pre-existing failures in CorsInitNpeSpec/MergeServiceSpec unrelated to this change)

## Fixes

- #42

🤖 Co-authored with AI: OpenCode (ollama-cloud/glm-5.1)