### PR TITLE
Sub-issue #69.3: Revert remote debug configuration from PR #4013

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -286,16 +286,9 @@ Test / testOptions ++= {
 
 Container / javaOptions ++= Seq(
   "-Dlogback.configurationFile=/logback-dev.xml",
-  "-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF"
+  "-Xdebug",
+  "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000",
+  "-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF",
 )
-
-// Local debug: create .debug file to enable remote debugging
-Container / javaOptions ++= {
-  if (file(".debug").exists) {
-    Seq("-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000")
-  } else {
-    Seq.empty
-  }
-}
 Container / containerLibs := Seq(("org.eclipse.jetty" % "jetty-runner" % JettyVersion).intransitive())
 Container / containerMain := "org.eclipse.jetty.runner.Runner"

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,69 +1,22 @@
 Debug GitBucket on IntelliJ
 ========
+Add following configuration for allowing remote debugging to `build.sbt`:
 
-## Setup
-
-Create a `.debug` file in the project root to enable remote debugging (this file is gitignored):
-
-```shell
-touch .debug
+```scala
+javaOptions in Jetty ++= Seq(
+  "-Xdebug",
+  "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000"
+)
 ```
 
-Start GitBucket:
+Run GitBucket:
 
 ```shell
-./sbt "~Container / start"
+$ sbt ~container:start
 ```
 
-## Attach Debugger
-
-Wait for `Listening for transport dt_socket at address: 8000`. Then in IntelliJ:
-
-1. **Run** → **Edit Configurations…**
-2. Click **+** → **Remote JVM Debug**
-3. Set **Host** = `localhost`, **Port** = `8000`
-4. Set **Search sources using module's classpath** = `gitbucket.main`
-5. Click **OK**, then click the Debug icon to attach
+In IntelliJ, create remote debug configuration as follows. Make sure port number is same as above configuration.
 
 ![Remote debug configuration on IntelliJ](remote_debug.png)
 
-Set a breakpoint (e.g., line 83 in `src/main/scala/gitbucket/core/controller/ApiController.scala`). Then trigger the endpoint:
-
-```shell
-curl http://localhost:8080/api/v3
-```
-
-## Troubleshooting
-
-### Breakpoint hits but "frames are not available"
-
-IntelliJ's source mapping is out of sync. Fix:
-
-1. **File** → **Invalidate Caches…** → **Invalidate and Restart**
-2. After restart, wait for sbt import to complete
-3. Re-run `./sbt "~Container / start"`
-4. Re-attach debugger
-
-You may need to disconnect/reconnect the debugger one to two times for frames to appear.
-
-### Port 8000 already in use
-
-A previous debug session didn't clean up. Kill the process:
-
-```shell
-lsof -ti:8000 | xargs kill -9
-```
-
-Then restart sbt.
-
-### Breakpoint doesn't hit
-
-Ensure code was compiled **after** debugger attached. Edit the source file (add/remove a blank line) to trigger recompilation, then retry the request.
-
-### Disable debugging
-
-Delete the `.debug` file and restart sbt:
-
-```shell
-rm .debug
-```
+Then you can start debugging on IntelliJ!


### PR DESCRIPTION
## Summary

Reverts `.debug` file-based debug configuration to unblock PR #4013 merge. Debug feature will be re-implemented in #70 using system property approach per reviewer request.

## Changes

- **build.sbt**: Reverted to master's always-on debug configuration (removed `.debug` file conditional logic)
- **doc/debug.md**: Reverted to master's简短 7-line version (removed detailed `.debug` file troubleshooting guide)
- **.gitignore**: No change (kept `.debug` entry)

## Outcome

- PR #4013 review thread on debug configuration resolved
- PR #4013 ready for merge
- Clean slate for #70 system property implementation

## Dependencies

- **Blocks:** PR #4013 merge
- **Unblocks:** #70 (system property debug implementation)

🤖 Co-authored with AI: OpenCode (ollama-cloud/qwen3.5:397b)