### PR TITLE
fix: restore missing L prefix in build.md line anchor

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -42,7 +42,7 @@ You can modify the logging configuration by editing `src/main/resources/logback-
 Note that HttpSession is cleared when auto-reloading happens.
 This is a bit annoying when developing features that require sign-in.
 You can keep HttpSession even if GitBucket is restarted by enabling this configuration in `build.sbt`:
-https://github.com/gitbucket/gitbucket/blob/3dcc0aee3c4413b05be7c03476626cb202674afc/build.sbt#292
+https://github.com/gitbucket/gitbucket/blob/3dcc0aee3c4413b05be7c03476626cb202674afc/build.sbt#L292
 
 Or by launching GitBucket with the following command:
 ```shell


### PR DESCRIPTION
## Summary

Restores the `L` prefix in the `build.sbt` line anchor on `doc/build.md` line 45. The anchor was `#292` instead of `#L292`, which GitHub does not recognize, making the link unresolvable.

## Changes

- `doc/build.md`: `#292` → `#L292` in the HttpSession keep-alive configuration link

## Verification

- Link now points to `#L292` which GitHub resolves correctly

## Outcome

- PR #4013 review thread on broken link resolved

Fixes #72