### PR TITLE
fix: restore missing keep-session comment in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -289,6 +289,7 @@ Container / javaOptions ++= Seq(
   "-Xdebug",
   "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8000",
   "-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF",
+  // "-Ddev-features=keep-session"
 )
 Container / containerLibs := Seq(("org.eclipse.jetty" % "jetty-runner" % JettyVersion).intransitive())
 Container / containerMain := "org.eclipse.jetty.runner.Runner"


### PR DESCRIPTION
## Summary

Restores the `// "-Ddev-features=keep-session"` comment in `build.sbt` that was dropped during an imprecise revert of the debug configuration. The upstream `gitbucket/gitbucket` master branch has this line — our `dev` was out of sync.

## Changes

- `build.sbt`: Added back `// "-Ddev-features=keep-session"` in `Container / javaOptions`

## Verification

- `build.sbt` `Container / javaOptions` block now matches upstream master exactly

Fixes the remaining part of #72