### PR TITLE
fix: reduce CI Java matrix to [17, 25] per PR #4013 review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17, 21, 25, 26]
+        java: [17, 25]
     steps:
     - uses: actions/checkout@v6
     - name: Cache


### PR DESCRIPTION
## Summary

Reduces CI build matrix from [17, 21, 25, 26] to [17, 25] per reviewer @takezoe's feedback.

## Changes

- `.github/workflows/build.yml`: `java: [17, 21, 25, 26]` → `java: [17, 25]`

## Rationale

Reviewer feedback: "I think 17 and 25 are practically enough. Even if we will add JDK versions, it should be discussed separately."

## Outcome

- PR #4013 review thread on Java matrix resolved

Fixes #71