### PR TITLE
fix: remove stale .debug entry from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ project/plugins/project/
 .bsp/
 .jvmopts
 .sbtopts
-.debug
 
 # Scala-IDE specific
 .scala_dependencies


### PR DESCRIPTION
## Summary
Remove stale `.debug` entry from `.gitignore`. The `.debug` file approach was reverted per upstream review feedback on PR #4013, making this gitignore entry unnecessary.

## Outcome
1 file changed, 1 deletion. No functional impact.

## Fixes
Closes #82