### PR TITLE
docs(swagger): #93 — add before/after annotation examples, remove .opencode references

### DIFF
--- a/.issues/93/spec.md
+++ b/.issues/93/spec.md
@@ -1,0 +1,9 @@
+# Synced from GitHub Issue #93 at 2026-05-23T05:00:00Z
+
+## Purpose
+
+Two fixes to the swagger documentation files:
+
+1. **Add before/after annotation examples** — Section 11 currently shows only the annotated (after) state. Implementors need to see what a route looks like before and after Swagger annotations to understand the transformation. Three before/after pairs covering key endpoint types (GET with path params, GET with query params, POST with body param) will make the annotation pattern immediately clear.
+
+2. **Remove .opencode-specific references** — The swagger docs currently reference issue #836, `critical-rules-060`, and `verification-before-completion`. These are internal tooling references that mean nothing outside this repository. The docs should use self-contained language that explains the principle without relying on external rule systems.

--- a/.issues/93/state.md
+++ b/.issues/93/state.md
@@ -1,0 +1,15 @@
+# State: Issue #93
+
+**Branch:** feature/93-swagger-examples-and-references
+**Workflow Phase:** pre-work
+**Created:** 2026-05-23T05:00:00Z
+**Last Updated:** 2026-05-23T05:00:00Z
+**Status:** initialized
+
+## Current State
+
+Pre-work initialization complete. Awaiting implementation task().
+
+## Blockers
+
+None.

--- a/doc/swagger/swagger-approach-validation.md
+++ b/doc/swagger/swagger-approach-validation.md
@@ -345,7 +345,7 @@ sbt test
 
 Expected output: `Tests: succeeded 7, failed 0, canceled 0, ignored 0, pending 0`
 
-All tests are behavioral — they spin up a Jetty server, send HTTP requests, and assert on live responses. If `sbt test` cannot execute (server fails to start, Jetty unavailable), the verdict is FAIL — NEVER substitute structural evidence (e.g., "the source files exist" or "the code compiles") for behavioral evidence. The classification question per issue #836 is: "does this test verify runtime behavior?" — the answer is YES for all seven SCs.
+All tests are behavioral — they spin up a Jetty server, send HTTP requests, and assert on live responses. If `sbt test` cannot execute (server fails to start, Jetty unavailable), the verdict is FAIL — never substitute structural evidence (e.g., "the source files exist" or "the code compiles") for behavioral evidence. The classification question for each test is: "does this test verify runtime behavior?" The answer is YES for all seven SCs — they spin up a Jetty server and assert on live HTTP responses.
 
 ## Success Criteria
 

--- a/doc/swagger/swagger.md
+++ b/doc/swagger/swagger.md
@@ -181,11 +181,11 @@ The anchor test file `CorsInitNpeSpec.scala` must be created as part of Phase 0/
 
 ### Evidence type classification for TDD tests
 
-All TDD tests in this project verify runtime behavior (HTTP responses from a running Jetty/GitBucket server). Per the runtime-behavioral evidence classification gate (issue #836):
+All TDD tests in this project verify runtime behavior (HTTP responses from a running Jetty/GitBucket server). The classification principle is substrate-determined: the evidence type depends on what the test substrate actually verifies, not on what a cheaper check could confirm.
 
 - Every `*SwaggerSpec.scala` test SC MUST be classified `behavioral` — the test sends HTTP requests to a live server and asserts on status codes, JSON responses, and header values
 - Structural evidence (source file existence, code pattern matching) is INSUFFICIENT for these tests — the classification question is "does this change affect runtime behavior?" and the answer is always YES for Swagger endpoint additions
-- If a behavioral test cannot execute (server unavailable, infrastructure failure), the SC verdict is FAIL per critical-rules-060 — NEVER substitute grep or structural checks for runtime verification
+- If a behavioral test cannot execute (server unavailable, infrastructure failure), the verdict is FAIL — NEVER substitute grep or structural checks for runtime verification
 
 ---
 
@@ -230,7 +230,7 @@ All F-checks are classified `behavioral` because they verify runtime behavior (H
 
 ### Mandatory regression testing requirement
 
-Run complete smoke tests F1–F11 **BEFORE any change** (pre-RED snapshot) and **AFTER verification-before-completion** (post-VBC snapshot). Diff the two snapshots. Every cell must match the "Expected" column post-change — do NOT submit if any regression is found.
+Run complete smoke tests F1–F11 **BEFORE any change** (pre-RED snapshot) and **AFTER final verification** (post-verification snapshot). Diff the two snapshots. Every cell must match the "Expected" column post-change — do NOT submit if any regression is found.
 
 ### Setup
 
@@ -323,7 +323,7 @@ Before and after any Swagger-related change:
 
 ## 9. Verification Checklist
 
-Post-implementation verification steps with evidence type classifications per the runtime-behavioral evidence classification gate (issue #836). The classification question is substrate-determined: "does this step verify runtime behavior?" If YES, the evidence type is `behavioral` regardless of whether a cheaper structural check exists.
+Post-implementation verification steps with evidence type classifications. The classification is substrate-determined: "does this step verify runtime behavior?" If YES, the evidence type is `behavioral` regardless of whether a cheaper structural check exists.
 
 | # | Step | Evidence Type | Rationale |
 |---|------|---------------|-----------|
@@ -339,7 +339,7 @@ Post-implementation verification steps with evidence type classifications per th
 | 10 | `ApiIntegrationTest` passes with zero regressions | `behavioral` | Runtime: integration test against live server |
 | 11 | Pre/post smoke test diff shows no regressions | `behavioral` | Runtime: HTTP responses from live server captured before and after |
 
-Steps 7 and 8 are `string` evidence — they verify code patterns, not runtime behavior. All other steps verify runtime behavior and are classified `behavioral`. Using structural evidence (e.g., "file exists") for behavioral steps is insufficient per the #836 classification gate.
+Steps 7 and 8 are `string` evidence — they verify code patterns, not runtime behavior. All other steps verify runtime behavior and are classified `behavioral`. Structural evidence (e.g., confirming a file exists) or string evidence (e.g., grep for a pattern) is insufficient for behavioral steps — they must be verified by executing against a live GitBucket instance.
 
 ---
 
@@ -356,39 +356,81 @@ If smoke tests reveal a pre-existing API regression:
 
 ## 11. Annotation Examples
 
-Reference examples showing the inline pattern with absolute route paths:
+Before/after pairs showing how bare routes transform into fully annotated Swagger endpoints. Each pair covers a distinct parameter pattern:
+
+### 11.1 GET with path parameters — `getIssue`
+
+**Before (un-annotated route):**
 
 ```scala
-get("/api/v3/repos/:owner/:repository/issues/:id", apiOperation[ApiIssue]("getIssue")
-  .summary("Get a single issue")
-  .description("Returns a single issue by its ID for the specified repository")
-  .parameters(
-    pathParam[String]("owner").description("Repository owner"),
-    pathParam[String]("repository").description("Repository name"),
-    pathParam[Int]("id").description("Issue number")
-  )
-  .responseMessages(ResponseMessage(404, "Issue not found"))) { ... }
+get("/api/v3/repos/:owner/:repository/issues/:id") { ... }
 ```
 
-```scala
-get("/api/v3/user", apiOperation[ApiUser]("getAuthenticatedUser")
-  .summary("Get the authenticated user")
-  .description("Returns the authenticated user")
-  .responseMessages(ResponseMessage(401, "Unauthorized"))) { ... }
-```
+**After (annotated route):**
 
 ```scala
-post("/api/v3/repos/:owner/:repository/issues", apiOperation[ApiIssue]("createIssue")
-  .summary("Create an issue")
-  .description("Create a new issue in the specified repository")
-  .parameters(
-    pathParam[String]("owner").description("Repository owner"),
-    pathParam[String]("repository").description("Repository name"),
-    bodyParam[CreateIssuePayload].description("Issue data")
-  )
-  .responseMessages(
-    ResponseMessage(201, "Issue created"),
-    ResponseMessage(401, "Unauthorized"),
-    ResponseMessage(422, "Validation failed")
-  )) { ... }
+get("/api/v3/repos/:owner/:repository/issues/:id",
+  apiOperation[ApiIssue]("getIssue")
+    .summary("Get a single issue")
+    .description("Returns a single issue by its ID for the specified repository")
+    .parameters(
+      pathParam[String]("owner").description("Repository owner"),
+      pathParam[String]("repository").description("Repository name"),
+      pathParam[Int]("id").description("Issue number")
+    )
+    .responseMessages(ResponseMessage(404, "Issue not found"))) { ... }
+```
+
+### 11.2 GET with query parameters — `listIssues`
+
+**Before (un-annotated route):**
+
+```scala
+get("/api/v3/repos/:owner/:repository/issues") { ... }
+```
+
+**After (annotated route):**
+
+```scala
+get("/api/v3/repos/:owner/:repository/issues",
+  apiOperation[Seq[ApiIssue]]("listIssues")
+    .summary("List repository issues")
+    .description("Returns a list of issues for the specified repository")
+    .parameters(
+      pathParam[String]("owner").description("Repository owner"),
+      pathParam[String]("repository").description("Repository name"),
+      queryParam[String]("state").description("Issue state: open, closed, or all").allowableValues("open", "closed", "all"),
+      queryParam[String]("sort").description("Sort field: created, updated, or comments").allowableValues("created", "updated", "comments"),
+      queryParam[String]("direction").description("Sort direction: asc or desc").allowableValues("asc", "desc"),
+      queryParam[Int]("page").description("Page number for pagination"),
+      queryParam[Int]("per_page").description("Number of issues per page")
+    )
+    .responseMessages(ResponseMessage(404, "Repository not found"))) { ... }
+```
+
+### 11.3 POST with body parameter — `createIssue`
+
+**Before (un-annotated route):**
+
+```scala
+post("/api/v3/repos/:owner/:repository/issues") { ... }
+```
+
+**After (annotated route):**
+
+```scala
+post("/api/v3/repos/:owner/:repository/issues",
+  apiOperation[ApiIssue]("createIssue")
+    .summary("Create an issue")
+    .description("Create a new issue in the specified repository")
+    .parameters(
+      pathParam[String]("owner").description("Repository owner"),
+      pathParam[String]("repository").description("Repository name"),
+      bodyParam[CreateIssuePayload].description("Issue data")
+    )
+    .responseMessages(
+      ResponseMessage(201, "Issue created"),
+      ResponseMessage(401, "Unauthorized"),
+      ResponseMessage(422, "Validation failed")
+    )) { ... }
 ```


### PR DESCRIPTION
## Summary

Add three before/after annotation pairs to Section 11 of `doc/swagger/swagger.md` covering GET with path params (getIssue), GET with query params (listIssues), and POST with body param (createIssue). Replace all `.opencode`-specific references (`issue #836`, `critical-rules-060`, `verification-before-completion`, `#836 classification gate`) with self-contained principles that explain the reasoning without external references.

## Outcome

- ✅ SC-1: Three before/after annotation pairs in Section 11
- ✅ SC-2: Before examples show un-annotated routes (no `apiOperation`)
- ✅ SC-3: After examples show same routes with `apiOperation` inline
- ✅ SC-4: Zero `#836` references in both swagger docs
- ✅ SC-5: Zero `critical-rules` references in both swagger docs
- ✅ SC-6: Zero `verification-before-completion` references in swagger.md
- ✅ SC-7–SC-9: Self-contained evidence classification language (no external references)
- ✅ SC-10: GET+query pair includes `queryParam` usage
- ✅ SC-11: POST+body pair includes `bodyParam` usage
- ✅ Adversarial audit: ALL 11 SCs PASS

Fixes #93

🤖 Co-authored with AI: opencode (ollama-cloud/glm-5.1)