### PR TITLE
Migrate .opencode from submodule to standalone sub-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ tmp/
 
 # Screenshots and misc
 *.png
+
+/.issues/
+
+# OpenCode sub-repo — managed independently
+.opencode/
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".opencode"]
-	path = .opencode
-	url = ../.opencode.git


### PR DESCRIPTION
## Summary

Migrate `.opencode/` from git submodule to standalone sub-repo. Remove `.gitmodules`, remove gitlink from index, re-clone as independent git repo, add `.opencode/` to `.gitignore`.

## Outcome

- `.gitmodules` deleted — no more submodule tracking
- `.opencode` re-cloned as standalone git repo at `https://github.com/michael-conrad/.opencode.git` on `dev` branch
- `.opencode/` added to `.gitignore` — parent repo will not track `.opencode/` contents
- `git clone` of parent repo no longer auto-clones `.opencode/` — it must be checked out separately

## Fixes

Closes #98